### PR TITLE
Convert specs to RSpec 3.4.1 syntax with Transpec

### DIFF
--- a/market_bot.gemspec
+++ b/market_bot.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency('typhoeus', '>= 0.6.0')
   gem.add_dependency('nokogiri', '>= 0')
 
-  gem.add_development_dependency('bundler', '~> 1.10')
+  gem.add_development_dependency('bundler', '> 1')
   gem.add_development_dependency('rake', '~> 10.0')
-  gem.add_development_dependency('rspec', '= 2.8.0')
+  gem.add_development_dependency('rspec', '> 2.14')
 end

--- a/spec/market_bot/android/app_spec.rb
+++ b/spec/market_bot/android/app_spec.rb
@@ -10,36 +10,36 @@ test_src_data4 = read_file(File.dirname(__FILE__), 'data', 'app_4.txt')
 
 def check_getters(app)
   it 'should populate the getters' do
-    app.title.should == 'Pop Dat'
-    app.rating.should == '4.7'
-    app.updated.should == 'August 26, 2011'
-    app.current_version.should == '1.0'
-    app.requires_android.should == '2.2 and up'
-    app.category.should == 'Arcade'
-    app.category_url.should == 'GAME_ARCADE'
-    app.installs.should == '500 - 1,000'
-    app.size.should == '9.0M'
-    app.price.should == '0'
-    app.content_rating.should == 'Everyone'
-    app.description.should =~ /^<div.*?>An action-packed blend of split-second skill and luck-based gameplay!/
-    app.votes.should == '9'
-    app.more_from_developer.should == [{:app_id=>"com.bluefroggaming.ghost_chicken"}]
-    app.users_also_installed.should == [{:app_id=>"com.mac.warzonepaid"}, {:app_id=>"com.caresilabs.wheeljoy.paid"}, {:app_id=>"com.blazingsoft.crosswolf"}, {:app_id=>"org.vladest.Popcorn"}, {:app_id=>"com.mtb.dds"}, {:app_id=>"com.hdl.datbom"}, {:app_id=>"cz.dejvice.rc.Marvin"}, {:app_id=>"com.spectaculator.spectaculator"}, {:app_id=>"com.seleuco.xpectrum"}, {:app_id=>"app.usp"}, {:app_id=>"com.fms.speccy"}, {:app_id=>"com.reynoldssoft.sampler"}, {:app_id=>"com.dylanpdx.blockybird"}]
-    app.related.should == [{:app_id=>"com.mac.warzonepaid"}, {:app_id=>"com.caresilabs.wheeljoy.paid"}, {:app_id=>"com.blazingsoft.crosswolf"}, {:app_id=>"org.vladest.Popcorn"}, {:app_id=>"com.mtb.dds"}, {:app_id=>"com.hdl.datbom"}, {:app_id=>"cz.dejvice.rc.Marvin"}, {:app_id=>"com.spectaculator.spectaculator"}, {:app_id=>"com.seleuco.xpectrum"}, {:app_id=>"app.usp"}, {:app_id=>"com.fms.speccy"}, {:app_id=>"com.reynoldssoft.sampler"}, {:app_id=>"com.dylanpdx.blockybird"}]
-    app.banner_icon_url.should == 'https://lh3.ggpht.com/e6QqjMM9K__moeCm2C5HRb0SmGX0XqzhnhiE1MUx8MdNVdQbQW9rhFX_qmtbtBxHAa0=w300'
-    app.banner_image_url.should == 'https://lh3.ggpht.com/e6QqjMM9K__moeCm2C5HRb0SmGX0XqzhnhiE1MUx8MdNVdQbQW9rhFX_qmtbtBxHAa0=w300'
-    app.website_url.should == 'http://bluefroggaming.com'
-    app.email.should == 'support@hdgames.zendesk.com'
-    app.youtube_video_ids.should == []
-    app.screenshot_urls.should == ["https://lh6.ggpht.com/JJWPKPEvz5ivZEeph_gA_oB3VOXYrIrY9lGdGFWHVT4FVub6cUKqxkh5VyxbvVqMXg=h310", "https://lh6.ggpht.com/kPGbJqu42Ukxoa_XZlWxo349y3zNKCayjBD35V2bbt26ZmgpHDegTf8sS5C1VOoAiw=h310", "https://lh3.ggpht.com/S9VMzKxAWSS3IxeUtLYPn-zDg9ojTpVxeHbd3RhHqtXazGRV6-S0jsuNh-GneV9eE2A=h310", "https://lh5.ggpht.com/G0U5k5PpvuEdflN58qzr3uKHGsXk3QqwwLIL_KxVfGNicR7Gn42smetbTBn9SRftnyk=h310", "https://lh6.ggpht.com/j03lPKqJss6066_Q6AbZikU33PWgoR07cPLFgoE5IoNyXwMG6QVX_3-SgI741vnaVnu7=h310", "https://lh3.ggpht.com/YBrG1Hjv7vgNLwp9PaR77gQHwdpInuluSnq9qPG4BwwU7LItCy4m6RQt9YM1sJH1hjdq=h310"]
-    app.full_screenshot_urls.should == ["https://lh6.ggpht.com/JJWPKPEvz5ivZEeph_gA_oB3VOXYrIrY9lGdGFWHVT4FVub6cUKqxkh5VyxbvVqMXg=h900", "https://lh6.ggpht.com/kPGbJqu42Ukxoa_XZlWxo349y3zNKCayjBD35V2bbt26ZmgpHDegTf8sS5C1VOoAiw=h900", "https://lh3.ggpht.com/S9VMzKxAWSS3IxeUtLYPn-zDg9ojTpVxeHbd3RhHqtXazGRV6-S0jsuNh-GneV9eE2A=h900", "https://lh5.ggpht.com/G0U5k5PpvuEdflN58qzr3uKHGsXk3QqwwLIL_KxVfGNicR7Gn42smetbTBn9SRftnyk=h900", "https://lh6.ggpht.com/j03lPKqJss6066_Q6AbZikU33PWgoR07cPLFgoE5IoNyXwMG6QVX_3-SgI741vnaVnu7=h900", "https://lh3.ggpht.com/YBrG1Hjv7vgNLwp9PaR77gQHwdpInuluSnq9qPG4BwwU7LItCy4m6RQt9YM1sJH1hjdq=h900"]
-    app.whats_new.should == nil
+    expect(app.title).to eq('Pop Dat')
+    expect(app.rating).to eq('4.7')
+    expect(app.updated).to eq('August 26, 2011')
+    expect(app.current_version).to eq('1.0')
+    expect(app.requires_android).to eq('2.2 and up')
+    expect(app.category).to eq('Arcade')
+    expect(app.category_url).to eq('GAME_ARCADE')
+    expect(app.installs).to eq('500 - 1,000')
+    expect(app.size).to eq('9.0M')
+    expect(app.price).to eq('0')
+    expect(app.content_rating).to eq('Everyone')
+    expect(app.description).to match(/^<div.*?>An action-packed blend of split-second skill and luck-based gameplay!/)
+    expect(app.votes).to eq('9')
+    expect(app.more_from_developer).to eq([{:app_id=>"com.bluefroggaming.ghost_chicken"}])
+    expect(app.users_also_installed).to eq([{:app_id=>"com.mac.warzonepaid"}, {:app_id=>"com.caresilabs.wheeljoy.paid"}, {:app_id=>"com.blazingsoft.crosswolf"}, {:app_id=>"org.vladest.Popcorn"}, {:app_id=>"com.mtb.dds"}, {:app_id=>"com.hdl.datbom"}, {:app_id=>"cz.dejvice.rc.Marvin"}, {:app_id=>"com.spectaculator.spectaculator"}, {:app_id=>"com.seleuco.xpectrum"}, {:app_id=>"app.usp"}, {:app_id=>"com.fms.speccy"}, {:app_id=>"com.reynoldssoft.sampler"}, {:app_id=>"com.dylanpdx.blockybird"}])
+    expect(app.related).to eq([{:app_id=>"com.mac.warzonepaid"}, {:app_id=>"com.caresilabs.wheeljoy.paid"}, {:app_id=>"com.blazingsoft.crosswolf"}, {:app_id=>"org.vladest.Popcorn"}, {:app_id=>"com.mtb.dds"}, {:app_id=>"com.hdl.datbom"}, {:app_id=>"cz.dejvice.rc.Marvin"}, {:app_id=>"com.spectaculator.spectaculator"}, {:app_id=>"com.seleuco.xpectrum"}, {:app_id=>"app.usp"}, {:app_id=>"com.fms.speccy"}, {:app_id=>"com.reynoldssoft.sampler"}, {:app_id=>"com.dylanpdx.blockybird"}])
+    expect(app.banner_icon_url).to eq('https://lh3.ggpht.com/e6QqjMM9K__moeCm2C5HRb0SmGX0XqzhnhiE1MUx8MdNVdQbQW9rhFX_qmtbtBxHAa0=w300')
+    expect(app.banner_image_url).to eq('https://lh3.ggpht.com/e6QqjMM9K__moeCm2C5HRb0SmGX0XqzhnhiE1MUx8MdNVdQbQW9rhFX_qmtbtBxHAa0=w300')
+    expect(app.website_url).to eq('http://bluefroggaming.com')
+    expect(app.email).to eq('support@hdgames.zendesk.com')
+    expect(app.youtube_video_ids).to eq([])
+    expect(app.screenshot_urls).to eq(["https://lh6.ggpht.com/JJWPKPEvz5ivZEeph_gA_oB3VOXYrIrY9lGdGFWHVT4FVub6cUKqxkh5VyxbvVqMXg=h310", "https://lh6.ggpht.com/kPGbJqu42Ukxoa_XZlWxo349y3zNKCayjBD35V2bbt26ZmgpHDegTf8sS5C1VOoAiw=h310", "https://lh3.ggpht.com/S9VMzKxAWSS3IxeUtLYPn-zDg9ojTpVxeHbd3RhHqtXazGRV6-S0jsuNh-GneV9eE2A=h310", "https://lh5.ggpht.com/G0U5k5PpvuEdflN58qzr3uKHGsXk3QqwwLIL_KxVfGNicR7Gn42smetbTBn9SRftnyk=h310", "https://lh6.ggpht.com/j03lPKqJss6066_Q6AbZikU33PWgoR07cPLFgoE5IoNyXwMG6QVX_3-SgI741vnaVnu7=h310", "https://lh3.ggpht.com/YBrG1Hjv7vgNLwp9PaR77gQHwdpInuluSnq9qPG4BwwU7LItCy4m6RQt9YM1sJH1hjdq=h310"])
+    expect(app.full_screenshot_urls).to eq(["https://lh6.ggpht.com/JJWPKPEvz5ivZEeph_gA_oB3VOXYrIrY9lGdGFWHVT4FVub6cUKqxkh5VyxbvVqMXg=h900", "https://lh6.ggpht.com/kPGbJqu42Ukxoa_XZlWxo349y3zNKCayjBD35V2bbt26ZmgpHDegTf8sS5C1VOoAiw=h900", "https://lh3.ggpht.com/S9VMzKxAWSS3IxeUtLYPn-zDg9ojTpVxeHbd3RhHqtXazGRV6-S0jsuNh-GneV9eE2A=h900", "https://lh5.ggpht.com/G0U5k5PpvuEdflN58qzr3uKHGsXk3QqwwLIL_KxVfGNicR7Gn42smetbTBn9SRftnyk=h900", "https://lh6.ggpht.com/j03lPKqJss6066_Q6AbZikU33PWgoR07cPLFgoE5IoNyXwMG6QVX_3-SgI741vnaVnu7=h900", "https://lh3.ggpht.com/YBrG1Hjv7vgNLwp9PaR77gQHwdpInuluSnq9qPG4BwwU7LItCy4m6RQt9YM1sJH1hjdq=h900"])
+    expect(app.whats_new).to eq(nil)
     #app.permissions.should == [{:security=>"dangerous", :group=>"Network communication", :description=>"full Internet access", :description_full=>"Allows the app to create network sockets."}, {:security=>"dangerous", :group=>"Phone calls", :description=>"read phone state and identity", :description_full=>"Allows the app to access the phone features of the device. An app with this permission can determine the phone number and serial number of this phone, whether a call is active, the number that call is connected to and the like."}, {:security=>"safe", :group=>"Network communication", :description=>"view network state", :description_full=>"Allows the app to view the state of all networks."}]
     # Stubbing out for now, can't find them in the redesigned page.
-    app.permissions.should == []
+    expect(app.permissions).to eq([])
 
-    app.rating_distribution.should == {5=>8, 4=>0, 3=>0, 2=>1, 1=>0}
-    app.html.class.should == String
+    expect(app.rating_distribution).to eq({5=>8, 4=>0, 3=>0, 2=>1, 1=>0})
+    expect(app.html.class).to eq(String)
   end
 end
 
@@ -47,50 +47,50 @@ describe 'App' do
   context 'Construction' do
     it 'should copy the app_id param' do
       app = App.new(test_id)
-      app.app_id.should == test_id
+      expect(app.app_id).to eq(test_id)
     end
 
     it 'should copy optional params' do
       hydra = Typhoeus::Hydra.new
       app = App.new(test_id, :hydra => hydra)
-      app.hydra.should equal(hydra)
+      expect(app.hydra).to equal(hydra)
     end
   end
 
   it 'should generate market URLs' do
-    App.new(test_id).market_url.should == "https://play.google.com/store/apps/details?id=#{test_id}&hl=en"
+    expect(App.new(test_id).market_url).to eq("https://play.google.com/store/apps/details?id=#{test_id}&hl=en")
   end
 
   context 'Parsing' do
     it 'should populate a hash with the correct keys/values' do
       result = App.parse(test_src_data)
 
-      result[:title].should == 'Pop Dat'
-      result[:rating].should == '4.7'
-      result[:updated].should == 'August 26, 2011'
-      result[:current_version].should == '1.0'
-      result[:requires_android].should == '2.2 and up'
-      result[:category].should == 'Arcade'
-      result[:category_url].should == 'GAME_ARCADE'
-      result[:installs].should == '500 - 1,000'
-      result[:size].should == '9.0M'
-      result[:price].should == '0'
-      result[:content_rating].should == 'Everyone'
-      result[:description].should =~ /An action-packed blend of split-second/
-      result[:votes].should == '9'
-      result[:developer].should == 'Blue Frog Gaming'
-      result[:banner_icon_url].should == 'https://lh3.ggpht.com/e6QqjMM9K__moeCm2C5HRb0SmGX0XqzhnhiE1MUx8MdNVdQbQW9rhFX_qmtbtBxHAa0=w300'
-      result[:website_url].should == 'http://bluefroggaming.com'
-      result[:email].should == 'support@hdgames.zendesk.com'
-      result[:youtube_video_ids].should == []
-      result[:screenshot_urls].should == ["https://lh6.ggpht.com/JJWPKPEvz5ivZEeph_gA_oB3VOXYrIrY9lGdGFWHVT4FVub6cUKqxkh5VyxbvVqMXg=h310", "https://lh6.ggpht.com/kPGbJqu42Ukxoa_XZlWxo349y3zNKCayjBD35V2bbt26ZmgpHDegTf8sS5C1VOoAiw=h310", "https://lh3.ggpht.com/S9VMzKxAWSS3IxeUtLYPn-zDg9ojTpVxeHbd3RhHqtXazGRV6-S0jsuNh-GneV9eE2A=h310", "https://lh5.ggpht.com/G0U5k5PpvuEdflN58qzr3uKHGsXk3QqwwLIL_KxVfGNicR7Gn42smetbTBn9SRftnyk=h310", "https://lh6.ggpht.com/j03lPKqJss6066_Q6AbZikU33PWgoR07cPLFgoE5IoNyXwMG6QVX_3-SgI741vnaVnu7=h310", "https://lh3.ggpht.com/YBrG1Hjv7vgNLwp9PaR77gQHwdpInuluSnq9qPG4BwwU7LItCy4m6RQt9YM1sJH1hjdq=h310"]
-      result[:full_screenshot_urls].should == ["https://lh6.ggpht.com/JJWPKPEvz5ivZEeph_gA_oB3VOXYrIrY9lGdGFWHVT4FVub6cUKqxkh5VyxbvVqMXg=h900", "https://lh6.ggpht.com/kPGbJqu42Ukxoa_XZlWxo349y3zNKCayjBD35V2bbt26ZmgpHDegTf8sS5C1VOoAiw=h900", "https://lh3.ggpht.com/S9VMzKxAWSS3IxeUtLYPn-zDg9ojTpVxeHbd3RhHqtXazGRV6-S0jsuNh-GneV9eE2A=h900", "https://lh5.ggpht.com/G0U5k5PpvuEdflN58qzr3uKHGsXk3QqwwLIL_KxVfGNicR7Gn42smetbTBn9SRftnyk=h900", "https://lh6.ggpht.com/j03lPKqJss6066_Q6AbZikU33PWgoR07cPLFgoE5IoNyXwMG6QVX_3-SgI741vnaVnu7=h900", "https://lh3.ggpht.com/YBrG1Hjv7vgNLwp9PaR77gQHwdpInuluSnq9qPG4BwwU7LItCy4m6RQt9YM1sJH1hjdq=h900"]      
-      result[:whats_new].should == nil
+      expect(result[:title]).to eq('Pop Dat')
+      expect(result[:rating]).to eq('4.7')
+      expect(result[:updated]).to eq('August 26, 2011')
+      expect(result[:current_version]).to eq('1.0')
+      expect(result[:requires_android]).to eq('2.2 and up')
+      expect(result[:category]).to eq('Arcade')
+      expect(result[:category_url]).to eq('GAME_ARCADE')
+      expect(result[:installs]).to eq('500 - 1,000')
+      expect(result[:size]).to eq('9.0M')
+      expect(result[:price]).to eq('0')
+      expect(result[:content_rating]).to eq('Everyone')
+      expect(result[:description]).to match(/An action-packed blend of split-second/)
+      expect(result[:votes]).to eq('9')
+      expect(result[:developer]).to eq('Blue Frog Gaming')
+      expect(result[:banner_icon_url]).to eq('https://lh3.ggpht.com/e6QqjMM9K__moeCm2C5HRb0SmGX0XqzhnhiE1MUx8MdNVdQbQW9rhFX_qmtbtBxHAa0=w300')
+      expect(result[:website_url]).to eq('http://bluefroggaming.com')
+      expect(result[:email]).to eq('support@hdgames.zendesk.com')
+      expect(result[:youtube_video_ids]).to eq([])
+      expect(result[:screenshot_urls]).to eq(["https://lh6.ggpht.com/JJWPKPEvz5ivZEeph_gA_oB3VOXYrIrY9lGdGFWHVT4FVub6cUKqxkh5VyxbvVqMXg=h310", "https://lh6.ggpht.com/kPGbJqu42Ukxoa_XZlWxo349y3zNKCayjBD35V2bbt26ZmgpHDegTf8sS5C1VOoAiw=h310", "https://lh3.ggpht.com/S9VMzKxAWSS3IxeUtLYPn-zDg9ojTpVxeHbd3RhHqtXazGRV6-S0jsuNh-GneV9eE2A=h310", "https://lh5.ggpht.com/G0U5k5PpvuEdflN58qzr3uKHGsXk3QqwwLIL_KxVfGNicR7Gn42smetbTBn9SRftnyk=h310", "https://lh6.ggpht.com/j03lPKqJss6066_Q6AbZikU33PWgoR07cPLFgoE5IoNyXwMG6QVX_3-SgI741vnaVnu7=h310", "https://lh3.ggpht.com/YBrG1Hjv7vgNLwp9PaR77gQHwdpInuluSnq9qPG4BwwU7LItCy4m6RQt9YM1sJH1hjdq=h310"])
+      expect(result[:full_screenshot_urls]).to eq(["https://lh6.ggpht.com/JJWPKPEvz5ivZEeph_gA_oB3VOXYrIrY9lGdGFWHVT4FVub6cUKqxkh5VyxbvVqMXg=h900", "https://lh6.ggpht.com/kPGbJqu42Ukxoa_XZlWxo349y3zNKCayjBD35V2bbt26ZmgpHDegTf8sS5C1VOoAiw=h900", "https://lh3.ggpht.com/S9VMzKxAWSS3IxeUtLYPn-zDg9ojTpVxeHbd3RhHqtXazGRV6-S0jsuNh-GneV9eE2A=h900", "https://lh5.ggpht.com/G0U5k5PpvuEdflN58qzr3uKHGsXk3QqwwLIL_KxVfGNicR7Gn42smetbTBn9SRftnyk=h900", "https://lh6.ggpht.com/j03lPKqJss6066_Q6AbZikU33PWgoR07cPLFgoE5IoNyXwMG6QVX_3-SgI741vnaVnu7=h900", "https://lh3.ggpht.com/YBrG1Hjv7vgNLwp9PaR77gQHwdpInuluSnq9qPG4BwwU7LItCy4m6RQt9YM1sJH1hjdq=h900"])      
+      expect(result[:whats_new]).to eq(nil)
       #result[:permissions].should == [{:security=>"dangerous", :group=>"Network communication", :description=>"full Internet access", :description_full=>"Allows the app to create network sockets."}, {:security=>"dangerous", :group=>"Phone calls", :description=>"read phone state and identity", :description_full=>"Allows the app to access the phone features of the device. An app with this permission can determine the phone number and serial number of this phone, whether a call is active, the number that call is connected to and the like."}, {:security=>"safe", :group=>"Network communication", :description=>"view network state", :description_full=>"Allows the app to view the state of all networks."}]
       # Stubbing out for now, can't find them in the redesigned page.
-      result[:permissions].should == []
-      result[:rating_distribution].should == {5=>8, 4=>0, 3=>0, 2=>1, 1=>0}
-      result[:html].should == test_src_data
+      expect(result[:permissions]).to eq([])
+      expect(result[:rating_distribution]).to eq({5=>8, 4=>0, 3=>0, 2=>1, 1=>0})
+      expect(result[:html]).to eq(test_src_data)
 
       result
     end
@@ -98,84 +98,84 @@ describe 'App' do
     it 'should populate a hash with the correct keys/values' do
       result = App.parse(test_src_data2)
 
-      result[:title].should == 'Evernote'
-      result[:rating].should == '4.6'
-      result[:updated].should == 'November 26, 2014'
-      result[:current_version].should == 'Varies with device'
-      result[:requires_android].should == 'Varies with device'
-      result[:category].should == 'Productivity'
-      result[:category_url].should == 'PRODUCTIVITY'
-      result[:size].should == 'Varies with device'
-      result[:price].should == '0'
-      result[:content_rating].should == 'Low Maturity'
-      result[:description].should =~ /New York Times/
-      result[:votes].should == '1134111'
-      result[:developer].should == 'Evernote Corporation'
-      result[:installs].should == '50,000,000 - 100,000,000'
-      result[:banner_icon_url].should == 'https://lh5.ggpht.com/u_ZwBnOs3s7nHA2v4XDCrJknAAVVHQIzK4mVF8tbx1n62-_LrDSopwHviqeNuDIFigc=w300'
-      result[:banner_image_url].should == 'https://lh5.ggpht.com/u_ZwBnOs3s7nHA2v4XDCrJknAAVVHQIzK4mVF8tbx1n62-_LrDSopwHviqeNuDIFigc=w300'
-      result[:website_url].should == 'http://evernote.com/privacy/'
-      result[:email].should == 'appstore-evernote-android@evernote.com'
-      result[:youtube_video_ids].should == ['UnpUIVO8Lmo']
-      result[:screenshot_urls].should == ["https://lh5.ggpht.com/PVFHj_lDlc52wwNu0by2CLmUrSHaAx6NINjbe9qmk-NPo-S5UUA8oghVARMBHEWgXDU=h310", "https://lh5.ggpht.com/KvbOit3FFnfbOZ6rG23sDEVuC4ALtLGV0Q0zwu6vMKDCO4u69_zI-IhmD3jOGuJLEj4=h310", "https://lh5.ggpht.com/TEWuyLgIH6_514_1xpcqpcjFPSxu82Sak2RPuwbtexRqe-kJuW81DF5IRdS4Lis1KJQ=h310", "https://lh4.ggpht.com/KeGMsBnchmH9gywdjA1x7fqUpQX0UrMA_cMZbvr2hYHLiYTsCKOescqniEO4DItuHxU=h310", "https://lh5.ggpht.com/zWJ3VVV-sjT0mSADljAMyecO3QmcoFBtLBs8bETznU49X8avDRv3_iF5TkJkzVlu8qU=h310", "https://lh5.ggpht.com/3DqrNu-AHqGQQTDper8eTzpm9XEUNq605BxNSCkx4yGopa9u0TD2jBPHXdgwEPp08A=h310", "https://lh6.ggpht.com/9h0D2tvXlf6oLsylnNaaSdxjmm6rJuWeHvML-8zg5xoTp4akAjSXRCylxvF_dNTfoTU=h310", "https://lh5.ggpht.com/ugk2h_v0RrvAdzL7FfqD4jBONrfzboL6eAuFmkqvWg7zQiJUvkz6GThCU5pnKzCmRA=h310", "https://lh4.ggpht.com/3QUx47b-R9ex02vhUDH8h2hN3VDgS7e7rNAP7JCPaxaXr-GClb7jsZEsAyIr5iiwzw=h310", "https://lh5.ggpht.com/1LW-N8yEdwS1s-ZuvQSzqNMLaLldL8wBdLHhDY9TvPV8NnxBWIUjVaDZuat8I7V5uh4=h310", "https://lh4.ggpht.com/hIueHCJKvvAUrTrQQSSv6-2zpKMV-fdTIITHhMGfrulky5fEAR6KM1cpyUFD_9_kqw=h310", "https://lh4.ggpht.com/l-rQJVY9d2ZYZXWXnKfLUkTk6gGCE79Xopb__YlFeVZ974PBgfF4lK8olU67TvK3-g=h310", "https://lh4.ggpht.com/Q_2sTO9l0OIdDv801S2mlJI-vugeKROHHyPcWf7Hvavs5d-MU2v2RWS6sUOrF79gH1Hn=h310", "https://lh5.ggpht.com/1O17OJEpW3qZcyEyfljRcIHUIIAOiBlCc5SxHPghyv0evV4h2g-ZooBAL3xkog-kZYU=h310", "https://lh6.ggpht.com/nyn0trJ4OTdpb3SkH7ItJu8W4DdFNNW9P2AAr0OBA9q0H7y8KLxtc144tlSZXQIVKjE=h310", "https://lh6.ggpht.com/Yo4DN_K0v27ltrEEmJxI9XHn_BtGIgH6kLkxG3hG8Q0PeCJPpDv0FzDXLxbK2gkx0wY=h310"]
-      result[:full_screenshot_urls].should == ["https://lh5.ggpht.com/PVFHj_lDlc52wwNu0by2CLmUrSHaAx6NINjbe9qmk-NPo-S5UUA8oghVARMBHEWgXDU=h900", "https://lh5.ggpht.com/KvbOit3FFnfbOZ6rG23sDEVuC4ALtLGV0Q0zwu6vMKDCO4u69_zI-IhmD3jOGuJLEj4=h900", "https://lh5.ggpht.com/TEWuyLgIH6_514_1xpcqpcjFPSxu82Sak2RPuwbtexRqe-kJuW81DF5IRdS4Lis1KJQ=h900", "https://lh4.ggpht.com/KeGMsBnchmH9gywdjA1x7fqUpQX0UrMA_cMZbvr2hYHLiYTsCKOescqniEO4DItuHxU=h900", "https://lh5.ggpht.com/zWJ3VVV-sjT0mSADljAMyecO3QmcoFBtLBs8bETznU49X8avDRv3_iF5TkJkzVlu8qU=h900", "https://lh5.ggpht.com/3DqrNu-AHqGQQTDper8eTzpm9XEUNq605BxNSCkx4yGopa9u0TD2jBPHXdgwEPp08A=h900", "https://lh6.ggpht.com/9h0D2tvXlf6oLsylnNaaSdxjmm6rJuWeHvML-8zg5xoTp4akAjSXRCylxvF_dNTfoTU=h900", "https://lh5.ggpht.com/ugk2h_v0RrvAdzL7FfqD4jBONrfzboL6eAuFmkqvWg7zQiJUvkz6GThCU5pnKzCmRA=h900", "https://lh4.ggpht.com/3QUx47b-R9ex02vhUDH8h2hN3VDgS7e7rNAP7JCPaxaXr-GClb7jsZEsAyIr5iiwzw=h900", "https://lh5.ggpht.com/1LW-N8yEdwS1s-ZuvQSzqNMLaLldL8wBdLHhDY9TvPV8NnxBWIUjVaDZuat8I7V5uh4=h900", "https://lh4.ggpht.com/hIueHCJKvvAUrTrQQSSv6-2zpKMV-fdTIITHhMGfrulky5fEAR6KM1cpyUFD_9_kqw=h900", "https://lh4.ggpht.com/l-rQJVY9d2ZYZXWXnKfLUkTk6gGCE79Xopb__YlFeVZ974PBgfF4lK8olU67TvK3-g=h900", "https://lh4.ggpht.com/Q_2sTO9l0OIdDv801S2mlJI-vugeKROHHyPcWf7Hvavs5d-MU2v2RWS6sUOrF79gH1Hn=h900", "https://lh5.ggpht.com/1O17OJEpW3qZcyEyfljRcIHUIIAOiBlCc5SxHPghyv0evV4h2g-ZooBAL3xkog-kZYU=h900", "https://lh6.ggpht.com/nyn0trJ4OTdpb3SkH7ItJu8W4DdFNNW9P2AAr0OBA9q0H7y8KLxtc144tlSZXQIVKjE=h900", "https://lh6.ggpht.com/Yo4DN_K0v27ltrEEmJxI9XHn_BtGIgH6kLkxG3hG8Q0PeCJPpDv0FzDXLxbK2gkx0wY=h900"]
-      result[:whats_new].should =~ /What's New/
+      expect(result[:title]).to eq('Evernote')
+      expect(result[:rating]).to eq('4.6')
+      expect(result[:updated]).to eq('November 26, 2014')
+      expect(result[:current_version]).to eq('Varies with device')
+      expect(result[:requires_android]).to eq('Varies with device')
+      expect(result[:category]).to eq('Productivity')
+      expect(result[:category_url]).to eq('PRODUCTIVITY')
+      expect(result[:size]).to eq('Varies with device')
+      expect(result[:price]).to eq('0')
+      expect(result[:content_rating]).to eq('Low Maturity')
+      expect(result[:description]).to match(/New York Times/)
+      expect(result[:votes]).to eq('1134111')
+      expect(result[:developer]).to eq('Evernote Corporation')
+      expect(result[:installs]).to eq('50,000,000 - 100,000,000')
+      expect(result[:banner_icon_url]).to eq('https://lh5.ggpht.com/u_ZwBnOs3s7nHA2v4XDCrJknAAVVHQIzK4mVF8tbx1n62-_LrDSopwHviqeNuDIFigc=w300')
+      expect(result[:banner_image_url]).to eq('https://lh5.ggpht.com/u_ZwBnOs3s7nHA2v4XDCrJknAAVVHQIzK4mVF8tbx1n62-_LrDSopwHviqeNuDIFigc=w300')
+      expect(result[:website_url]).to eq('http://evernote.com/privacy/')
+      expect(result[:email]).to eq('appstore-evernote-android@evernote.com')
+      expect(result[:youtube_video_ids]).to eq(['UnpUIVO8Lmo'])
+      expect(result[:screenshot_urls]).to eq(["https://lh5.ggpht.com/PVFHj_lDlc52wwNu0by2CLmUrSHaAx6NINjbe9qmk-NPo-S5UUA8oghVARMBHEWgXDU=h310", "https://lh5.ggpht.com/KvbOit3FFnfbOZ6rG23sDEVuC4ALtLGV0Q0zwu6vMKDCO4u69_zI-IhmD3jOGuJLEj4=h310", "https://lh5.ggpht.com/TEWuyLgIH6_514_1xpcqpcjFPSxu82Sak2RPuwbtexRqe-kJuW81DF5IRdS4Lis1KJQ=h310", "https://lh4.ggpht.com/KeGMsBnchmH9gywdjA1x7fqUpQX0UrMA_cMZbvr2hYHLiYTsCKOescqniEO4DItuHxU=h310", "https://lh5.ggpht.com/zWJ3VVV-sjT0mSADljAMyecO3QmcoFBtLBs8bETznU49X8avDRv3_iF5TkJkzVlu8qU=h310", "https://lh5.ggpht.com/3DqrNu-AHqGQQTDper8eTzpm9XEUNq605BxNSCkx4yGopa9u0TD2jBPHXdgwEPp08A=h310", "https://lh6.ggpht.com/9h0D2tvXlf6oLsylnNaaSdxjmm6rJuWeHvML-8zg5xoTp4akAjSXRCylxvF_dNTfoTU=h310", "https://lh5.ggpht.com/ugk2h_v0RrvAdzL7FfqD4jBONrfzboL6eAuFmkqvWg7zQiJUvkz6GThCU5pnKzCmRA=h310", "https://lh4.ggpht.com/3QUx47b-R9ex02vhUDH8h2hN3VDgS7e7rNAP7JCPaxaXr-GClb7jsZEsAyIr5iiwzw=h310", "https://lh5.ggpht.com/1LW-N8yEdwS1s-ZuvQSzqNMLaLldL8wBdLHhDY9TvPV8NnxBWIUjVaDZuat8I7V5uh4=h310", "https://lh4.ggpht.com/hIueHCJKvvAUrTrQQSSv6-2zpKMV-fdTIITHhMGfrulky5fEAR6KM1cpyUFD_9_kqw=h310", "https://lh4.ggpht.com/l-rQJVY9d2ZYZXWXnKfLUkTk6gGCE79Xopb__YlFeVZ974PBgfF4lK8olU67TvK3-g=h310", "https://lh4.ggpht.com/Q_2sTO9l0OIdDv801S2mlJI-vugeKROHHyPcWf7Hvavs5d-MU2v2RWS6sUOrF79gH1Hn=h310", "https://lh5.ggpht.com/1O17OJEpW3qZcyEyfljRcIHUIIAOiBlCc5SxHPghyv0evV4h2g-ZooBAL3xkog-kZYU=h310", "https://lh6.ggpht.com/nyn0trJ4OTdpb3SkH7ItJu8W4DdFNNW9P2AAr0OBA9q0H7y8KLxtc144tlSZXQIVKjE=h310", "https://lh6.ggpht.com/Yo4DN_K0v27ltrEEmJxI9XHn_BtGIgH6kLkxG3hG8Q0PeCJPpDv0FzDXLxbK2gkx0wY=h310"])
+      expect(result[:full_screenshot_urls]).to eq(["https://lh5.ggpht.com/PVFHj_lDlc52wwNu0by2CLmUrSHaAx6NINjbe9qmk-NPo-S5UUA8oghVARMBHEWgXDU=h900", "https://lh5.ggpht.com/KvbOit3FFnfbOZ6rG23sDEVuC4ALtLGV0Q0zwu6vMKDCO4u69_zI-IhmD3jOGuJLEj4=h900", "https://lh5.ggpht.com/TEWuyLgIH6_514_1xpcqpcjFPSxu82Sak2RPuwbtexRqe-kJuW81DF5IRdS4Lis1KJQ=h900", "https://lh4.ggpht.com/KeGMsBnchmH9gywdjA1x7fqUpQX0UrMA_cMZbvr2hYHLiYTsCKOescqniEO4DItuHxU=h900", "https://lh5.ggpht.com/zWJ3VVV-sjT0mSADljAMyecO3QmcoFBtLBs8bETznU49X8avDRv3_iF5TkJkzVlu8qU=h900", "https://lh5.ggpht.com/3DqrNu-AHqGQQTDper8eTzpm9XEUNq605BxNSCkx4yGopa9u0TD2jBPHXdgwEPp08A=h900", "https://lh6.ggpht.com/9h0D2tvXlf6oLsylnNaaSdxjmm6rJuWeHvML-8zg5xoTp4akAjSXRCylxvF_dNTfoTU=h900", "https://lh5.ggpht.com/ugk2h_v0RrvAdzL7FfqD4jBONrfzboL6eAuFmkqvWg7zQiJUvkz6GThCU5pnKzCmRA=h900", "https://lh4.ggpht.com/3QUx47b-R9ex02vhUDH8h2hN3VDgS7e7rNAP7JCPaxaXr-GClb7jsZEsAyIr5iiwzw=h900", "https://lh5.ggpht.com/1LW-N8yEdwS1s-ZuvQSzqNMLaLldL8wBdLHhDY9TvPV8NnxBWIUjVaDZuat8I7V5uh4=h900", "https://lh4.ggpht.com/hIueHCJKvvAUrTrQQSSv6-2zpKMV-fdTIITHhMGfrulky5fEAR6KM1cpyUFD_9_kqw=h900", "https://lh4.ggpht.com/l-rQJVY9d2ZYZXWXnKfLUkTk6gGCE79Xopb__YlFeVZ974PBgfF4lK8olU67TvK3-g=h900", "https://lh4.ggpht.com/Q_2sTO9l0OIdDv801S2mlJI-vugeKROHHyPcWf7Hvavs5d-MU2v2RWS6sUOrF79gH1Hn=h900", "https://lh5.ggpht.com/1O17OJEpW3qZcyEyfljRcIHUIIAOiBlCc5SxHPghyv0evV4h2g-ZooBAL3xkog-kZYU=h900", "https://lh6.ggpht.com/nyn0trJ4OTdpb3SkH7ItJu8W4DdFNNW9P2AAr0OBA9q0H7y8KLxtc144tlSZXQIVKjE=h900", "https://lh6.ggpht.com/Yo4DN_K0v27ltrEEmJxI9XHn_BtGIgH6kLkxG3hG8Q0PeCJPpDv0FzDXLxbK2gkx0wY=h900"])
+      expect(result[:whats_new]).to match(/What's New/)
       #result[:permissions].should == [{:security=>"dangerous", :group=>"Hardware controls", :description=>"record audio", :description_full=>"Allows the app to access the audio record path."}, {:security=>"dangerous", :group=>"Hardware controls", :description=>"take pictures and videos", :description_full=>"Allows the app to take pictures and videos with the camera. This allows the app at any time to collect images the camera is seeing."}, {:security=>"dangerous", :group=>"Your location", :description=>"coarse (network-based) location", :description_full=>"Access coarse location sources such as the cellular network database to determine an approximate tablet location, where available. Malicious apps may use this to determine approximately where you are. Access coarse location sources such as the cellular network database to determine an approximate phone location, where available. Malicious apps may use this to determine approximately where you are."}, {:security=>"dangerous", :group=>"Your location", :description=>"fine (GPS) location", :description_full=>"Access fine location sources such as the Global Positioning System on the tablet, where available. Malicious apps may use this to determine where you are, and may consume additional battery power. Access fine location sources such as the Global Positioning System on the phone, where available. Malicious apps may use this to determine where you are, and may consume additional battery power."}, {:security=>"dangerous", :group=>"Network communication", :description=>"full Internet access", :description_full=>"Allows the app to create network sockets."}, {:security=>"dangerous", :group=>"Your personal information", :description=>"read contact data", :description_full=>"Allows the app to read all of the contact (address) data stored on your tablet. Malicious apps may use this to send your data to other people. Allows the app to read all of the contact (address) data stored on your phone. Malicious apps may use this to send your data to other people."}, {:security=>"dangerous", :group=>"Your personal information", :description=>"read sensitive log data", :description_full=>"Allows the app to read from the system's various log files. This allows it to discover general information about what you are doing with the tablet, potentially including personal or private information. Allows the app to read from the system's various log files. This allows it to discover general information about what you are doing with the phone, potentially including personal or private information."}, {:security=>"dangerous", :group=>"Your personal information", :description=>"read calendar events plus confidential information", :description_full=>"Allows the app to read all calendar events stored on your tablet, including those of friends or coworkers. Malicious apps may extract personal information from these calendars without the owners' knowledge. Allows the app to read all calendar events stored on your phone, including those of friends or coworkers. Malicious apps may extract personal information from these calendars without the owners' knowledge."}, {:security=>"dangerous", :group=>"Phone calls", :description=>"read phone state and identity", :description_full=>"Allows the app to access the phone features of the device. An app with this permission can determine the phone number and serial number of this phone, whether a call is active, the number that call is connected to and the like."}, {:security=>"dangerous", :group=>"Storage", :description=>"modify/delete USB storage contents modify/delete SD card contents", :description_full=>"Allows the app to write to the USB storage. Allows the app to write to the SD card."}, {:security=>"dangerous", :group=>"System tools", :description=>"prevent tablet from sleeping prevent phone from sleeping", :description_full=>"Allows the app to prevent the tablet from going to sleep. Allows the app to prevent the phone from going to sleep."}, {:security=>"safe", :group=>"Your accounts", :description=>"discover known accounts", :description_full=>"Allows the app to get the list of accounts known by the tablet. Allows the app to get the list of accounts known by the phone."}, {:security=>"safe", :group=>"Hardware controls", :description=>"control vibrator", :description_full=>"Allows the app to control the vibrator."}, {:security=>"safe", :group=>"Network communication", :description=>"view network state", :description_full=>"Allows the app to view the state of all networks."}, {:security=>"safe", :group=>"Network communication", :description=>"view Wi-Fi state", :description_full=>"Allows the app to view the information about the state of Wi-Fi."}, {:security=>"safe", :group=>"Default", :description=>"Market billing service", :description_full=>"Allows the user to purchase items through Market from within this application"}]
       # Stubbing out for now, can't find them in the redesigned page.
-      result[:permissions].should == []
-      result[:rating_distribution].should == {5=>833055, 4=>229395, 3=>39241, 2=>12003, 1=>20202}
-      result[:html].should == test_src_data2
+      expect(result[:permissions]).to eq([])
+      expect(result[:rating_distribution]).to eq({5=>833055, 4=>229395, 3=>39241, 2=>12003, 1=>20202})
+      expect(result[:html]).to eq(test_src_data2)
     end
 
     it 'should populate a hash with the correct keys/values' do
       result = App.parse(test_src_data3)
 
-      result[:title].should == 'WeatherPro'
-      result[:updated].should == 'October 1, 2014'
-      result[:current_version].should == '3.5.2'
-      result[:requires_android].should == '2.3 and up'
-      result[:category].should == 'Weather'
-      result[:category_url].should == 'WEATHER'
-      result[:size].should == '9.1M'
-      result[:price].should == '$2.99'
-      result[:content_rating].should == 'Low Maturity'
-      result[:description].should =~ /^.*WeatherPro answers the question - what's the best Android Weather app/
-      result[:developer].should == 'MeteoGroup'
-      result[:rating].should == "4.4"
-      result[:votes].should == "32543"
-      result[:banner_icon_url].should == 'https://lh5.ggpht.com/gEwuqrqo9Hu2qRNfBi8bLs0XByBQEmhvBhyNXJLuPmrT47GNfljir8ddam-Plzhovrg=w300'
-      result[:banner_image_url].should == 'https://lh5.ggpht.com/gEwuqrqo9Hu2qRNfBi8bLs0XByBQEmhvBhyNXJLuPmrT47GNfljir8ddam-Plzhovrg=w300'
-      result[:website_url].should == 'http://www.meteogroup.com/en/gb/about-meteogroup/privacy-policy-and-cookies.html'
-      result[:email].should == 'support@android.weatherpro.de'
-      result[:youtube_video_ids].should == []
-      result[:whats_new].should =~ /Access to WeatherPro app via car infotainment screen/
+      expect(result[:title]).to eq('WeatherPro')
+      expect(result[:updated]).to eq('October 1, 2014')
+      expect(result[:current_version]).to eq('3.5.2')
+      expect(result[:requires_android]).to eq('2.3 and up')
+      expect(result[:category]).to eq('Weather')
+      expect(result[:category_url]).to eq('WEATHER')
+      expect(result[:size]).to eq('9.1M')
+      expect(result[:price]).to eq('$2.99')
+      expect(result[:content_rating]).to eq('Low Maturity')
+      expect(result[:description]).to match(/^.*WeatherPro answers the question - what's the best Android Weather app/)
+      expect(result[:developer]).to eq('MeteoGroup')
+      expect(result[:rating]).to eq("4.4")
+      expect(result[:votes]).to eq("32543")
+      expect(result[:banner_icon_url]).to eq('https://lh5.ggpht.com/gEwuqrqo9Hu2qRNfBi8bLs0XByBQEmhvBhyNXJLuPmrT47GNfljir8ddam-Plzhovrg=w300')
+      expect(result[:banner_image_url]).to eq('https://lh5.ggpht.com/gEwuqrqo9Hu2qRNfBi8bLs0XByBQEmhvBhyNXJLuPmrT47GNfljir8ddam-Plzhovrg=w300')
+      expect(result[:website_url]).to eq('http://www.meteogroup.com/en/gb/about-meteogroup/privacy-policy-and-cookies.html')
+      expect(result[:email]).to eq('support@android.weatherpro.de')
+      expect(result[:youtube_video_ids]).to eq([])
+      expect(result[:whats_new]).to match(/Access to WeatherPro app via car infotainment screen/)
       #result[:permissions].should == [{:security=>"dangerous", :group=>"Your location", :description=>"fine (GPS) location", :description_full=>"Access fine location sources such as the Global Positioning System on the tablet, where available. Malicious apps may use this to determine where you are, and may consume additional battery power. Access fine location sources such as the Global Positioning System on the phone, where available. Malicious apps may use this to determine where you are, and may consume additional battery power."}, {:security=>"dangerous", :group=>"Network communication", :description=>"full Internet access", :description_full=>"Allows the app to create network sockets."}, {:security=>"safe", :group=>"Network communication", :description=>"view network state", :description_full=>"Allows the app to view the state of all networks."}]
       # Stubbing out for now, can't find them in the redesigned page.
-      result[:permissions].should == []
-      result[:rating_distribution].should == {5=>20184, 4=>8344, 3=>1749, 2=>801, 1=>1454}
-      result[:html].should == test_src_data3
+      expect(result[:permissions]).to eq([])
+      expect(result[:rating_distribution]).to eq({5=>20184, 4=>8344, 3=>1749, 2=>801, 1=>1454})
+      expect(result[:html]).to eq(test_src_data3)
     end
 
     it 'should populate the associated apps keys' do
       result = App.parse(test_src_data2)
 
-      result[:related].should be_a(Array)
-      result[:users_also_installed].should be_a(Array)
-      result[:more_from_developer].should be_a(Array)
+      expect(result[:related]).to be_a(Array)
+      expect(result[:users_also_installed]).to be_a(Array)
+      expect(result[:more_from_developer]).to be_a(Array)
 
-      result[:related].first[:app_id].should == 'com.socialnmobile.dictapps.notepad.color.note'
-      result[:users_also_installed].first[:app_id].should == 'com.socialnmobile.dictapps.notepad.color.note'
-      result[:more_from_developer].first[:app_id].should == 'com.evernote.widget'
+      expect(result[:related].first[:app_id]).to eq('com.socialnmobile.dictapps.notepad.color.note')
+      expect(result[:users_also_installed].first[:app_id]).to eq('com.socialnmobile.dictapps.notepad.color.note')
+      expect(result[:more_from_developer].first[:app_id]).to eq('com.evernote.widget')
     end
 
     it 'should populate the reviews' do
       result = App.parse(test_src_data4)
-      result[:reviews].should be_a(Array)
+      expect(result[:reviews]).to be_a(Array)
       result[:reviews].size == 9
-      result[:reviews][2][:author_name].should == 'sidi Gueye'
-      result[:reviews][2][:review_title].should  == 'Trop cool'
-      result[:reviews][2][:review_text].should  == "J'ai vraiment adoré l'appli c trop cool !!"
-      result[:reviews][2][:review_score].should  == 5
+      expect(result[:reviews][2][:author_name]).to eq('sidi Gueye')
+      expect(result[:reviews][2][:review_title]).to  eq('Trop cool')
+      expect(result[:reviews][2][:review_text]).to  eq("J'ai vraiment adoré l'appli c trop cool !!")
+      expect(result[:reviews][2][:review_score]).to  eq(5)
     end
 
   end
@@ -222,7 +222,7 @@ describe 'App' do
       hydra.run
 
       it 'should call the callback' do
-        callback_flag.should be(true)
+        expect(callback_flag).to be(true)
       end
 
       check_getters(app)
@@ -246,11 +246,11 @@ describe 'App' do
       hydra.run
 
       it 'should call the callback' do
-        callback_flag.should be(true)
+        expect(callback_flag).to be(true)
       end
 
       it 'should set error to the exception' do
-        error.should be_a(Exception)
+        expect(error).to be_a(Exception)
       end
     end
   end

--- a/spec/market_bot/android/developer_spec.rb
+++ b/spec/market_bot/android/developer_spec.rb
@@ -15,8 +15,8 @@ end
 
 def check_results(results)
   it 'should return valid results' do
-    results.length.should == 24
-    results[0][:title].should == "New Words With Friends"
+    expect(results.length).to eq(24)
+    expect(results[0][:title]).to eq("New Words With Friends")
   end
 end
 
@@ -24,13 +24,13 @@ describe 'developer' do
   context 'Construction' do
     it 'should copy params' do
       dev = Developer.new(test_developer_id)
-      dev.identifier.should == test_developer_id
+      expect(dev.identifier).to eq(test_developer_id)
     end
 
     it 'should copy optional params' do
       hydra = Typhoeus::Hydra.new
       dev = Developer.new(test_developer_id, :hydra => hydra)
-      dev.hydra.should equal(hydra)
+      expect(dev.hydra).to equal(hydra)
     end
   end
 

--- a/spec/market_bot/android/leaderboard_spec.rb
+++ b/spec/market_bot/android/leaderboard_spec.rb
@@ -27,23 +27,23 @@ end
 
 def check_results(results)
   it 'should return valid results' do
-    results.length.should == 96
+    expect(results.length).to eq(96)
     results.each do |app|
-      app.keys.sort.should == [:developer, :icon_url, :market_id, :market_url, :price_usd, :stars, :title]
-      app[:market_url].should == App.new(app[:market_id]).market_url
-      app[:price_usd].should =~ /^\$\d+\.\d{2}$/
-      app[:stars].to_f.should > 0.0
-      app[:stars].to_f.should <= 5.0
+      expect(app.keys.sort).to eq([:developer, :icon_url, :market_id, :market_url, :price_usd, :stars, :title])
+      expect(app[:market_url]).to eq(App.new(app[:market_id]).market_url)
+      expect(app[:price_usd]).to match(/^\$\d+\.\d{2}$/)
+      expect(app[:stars].to_f).to be > 0.0
+      expect(app[:stars].to_f).to be <= 5.0
     end
   end
 
   it 'should have the top ranking app with valid details' do
-    results.first[:developer].should == 'Mojang'
-    results.first[:market_id].should == 'com.mojang.minecraftpe'
-    results.first[:market_url].should == 'https://play.google.com/store/apps/details?id=com.mojang.minecraftpe&hl=en'
-    results.first[:price_usd].should == '$6.99'
-    results.first[:stars].should == '4.5'
-    results.first[:title].should == "Minecraft - Pocket Edition"
+    expect(results.first[:developer]).to eq('Mojang')
+    expect(results.first[:market_id]).to eq('com.mojang.minecraftpe')
+    expect(results.first[:market_url]).to eq('https://play.google.com/store/apps/details?id=com.mojang.minecraftpe&hl=en')
+    expect(results.first[:price_usd]).to eq('$6.99')
+    expect(results.first[:stars]).to eq('4.5')
+    expect(results.first[:title]).to eq("Minecraft - Pocket Edition")
   end
 
 end
@@ -52,50 +52,50 @@ describe 'Leaderboard' do
   context 'Construction' do
     it 'should copy params' do
       lb =MarketBot::Android::Leaderboard.new(test_id, test_category)
-      lb.identifier.should == test_id
-      lb.category.should == test_category
+      expect(lb.identifier).to eq(test_id)
+      expect(lb.category).to eq(test_category)
     end
 
     it 'should copy optional params' do
       hydra = Typhoeus::Hydra.new
       lb = MarketBot::Android::Leaderboard.new(test_id, test_category, :hydra => hydra)
-      lb.hydra.should equal(hydra)
+      expect(lb.hydra).to equal(hydra)
     end
 
     it 'should have an optional category parameter' do
       lb = MarketBot::Android::Leaderboard.new(test_id)
-      lb.identifier.should == test_id
-      lb.category.should == nil
+      expect(lb.identifier).to eq(test_id)
+      expect(lb.category).to eq(nil)
     end
   end
 
   it 'should generate URLs using min and max page ranges' do
     lb = MarketBot::Android::Leaderboard.new(test_id, test_category)
     urls = lb.market_urls(:min_page => 1, :max_page => 3)
-    urls.should == [
+    expect(urls).to eq([
       'https://play.google.com/store/apps/category/ARCADE/collection/topselling_paid?start=0&gl=us&num=24&hl=en',
       'https://play.google.com/store/apps/category/ARCADE/collection/topselling_paid?start=24&gl=us&num=24&hl=en',
       'https://play.google.com/store/apps/category/ARCADE/collection/topselling_paid?start=48&gl=us&num=24&hl=en'
-    ]
+    ])
   end
 
   it 'should generate URLs using country' do
     lb = MarketBot::Android::Leaderboard.new(test_id, test_category)
     urls = lb.market_urls(:min_page => 1, :max_page => 3, :country => 'au')
-    urls.should == [
+    expect(urls).to eq([
       'https://play.google.com/store/apps/category/ARCADE/collection/topselling_paid?start=0&gl=au&num=24&hl=en',
       'https://play.google.com/store/apps/category/ARCADE/collection/topselling_paid?start=24&gl=au&num=24&hl=en',
       'https://play.google.com/store/apps/category/ARCADE/collection/topselling_paid?start=48&gl=au&num=24&hl=en'
-    ]
+    ])
   end
 
 
   it 'should convert ranks to market leaderboard pages (24 apps per page)' do
     app = MarketBot::Android::Leaderboard.new(test_id, test_category)
-    app.rank_to_page(1).should == 1
-    app.rank_to_page(24).should == 1
-    app.rank_to_page(25).should == 2
-    app.rank_to_page(48).should == 2
+    expect(app.rank_to_page(1)).to eq(1)
+    expect(app.rank_to_page(24)).to eq(1)
+    expect(app.rank_to_page(25)).to eq(2)
+    expect(app.rank_to_page(48)).to eq(2)
   end
 
   describe 'Updating' do
@@ -125,15 +125,15 @@ describe 'Leaderboard' do
         lb = MarketBot::Android::Leaderboard.new('editors_choice', nil, :hydra => hydra)
         lb.update
 
-        lb.results.count.should == 61
+        expect(lb.results.count).to eq(61)
 
         app = lb.results.last
 
-        app[:title].should == '10000000'
-        app[:price_usd].should == "$2.89"
-        app[:developer].should == 'EightyEight Games'
-        app[:market_id].should == 'com.eightyeightgames.tenmillion'
-        app[:market_url].should == 'https://play.google.com/store/apps/details?id=com.eightyeightgames.tenmillion&hl=en'
+        expect(app[:title]).to eq('10000000')
+        expect(app[:price_usd]).to eq("$2.89")
+        expect(app[:developer]).to eq('EightyEight Games')
+        expect(app[:market_id]).to eq('com.eightyeightgames.tenmillion')
+        expect(app[:market_url]).to eq('https://play.google.com/store/apps/details?id=com.eightyeightgames.tenmillion&hl=en')
       end
     end
   end

--- a/spec/market_bot/movie/leaderboard_spec.rb
+++ b/spec/market_bot/movie/leaderboard_spec.rb
@@ -14,12 +14,12 @@ end
 
 def check_results(results)
   it 'should have the top ranking app with valid details' do
-    results.first[:genre].should == 'Comedy'
-    results.first[:stars].should == '3.6'
-    results.first[:title].should == 'Dear White People'
-    results.first[:price_usd].should == '$4.99'
-    results.first[:market_id].should == 'vRpjPMDxpg0'
-    results.first[:market_url].should == 'https://play.google.com/store/movies/details/Dear_White_People?id=vRpjPMDxpg0&hl=en'
+    expect(results.first[:genre]).to eq('Comedy')
+    expect(results.first[:stars]).to eq('3.6')
+    expect(results.first[:title]).to eq('Dear White People')
+    expect(results.first[:price_usd]).to eq('$4.99')
+    expect(results.first[:market_id]).to eq('vRpjPMDxpg0')
+    expect(results.first[:market_url]).to eq('https://play.google.com/store/movies/details/Dear_White_People?id=vRpjPMDxpg0&hl=en')
   end
 end
 
@@ -27,20 +27,20 @@ describe 'Leaderboard' do
   context 'Construction' do
     it 'should copy params' do
       lb = MarketBot::Movie::Leaderboard.new(test_id, test_category)
-      lb.identifier.should == test_id
-      lb.category.should == test_category
+      expect(lb.identifier).to eq(test_id)
+      expect(lb.category).to eq(test_category)
     end
 
     it 'should copy optional params' do
       hydra = Typhoeus::Hydra.new
       lb = MarketBot::Movie::Leaderboard.new(test_id, test_category, :hydra => hydra)
-      lb.hydra.should equal(hydra)
+      expect(lb.hydra).to equal(hydra)
     end
 
     it 'should have an optional category parameter' do
       lb = MarketBot::Movie::Leaderboard.new(test_id)
-      lb.identifier.should == test_id
-      lb.category.should == nil
+      expect(lb.identifier).to eq(test_id)
+      expect(lb.category).to eq(nil)
     end
   end
 


### PR DESCRIPTION
In Gemfile, manually updated rspec and bundler versions, required to fix the bundle exec and
make transpec work. Everything else here is an automated update using Transpec.

---

This conversion is done by Transpec 3.2.2 with the following command:
    transpec
- 159 conversions
  from: obj.should
    to: expect(obj).to
- 139 conversions
  from: == expected
    to: eq(expected)
- 7 conversions
  from: =~ /pattern/
    to: match(/pattern/)
- 1 conversion
  from: <= expected
    to: be <= expected
- 1 conversion
  from: > expected
    to: be > expected

For more details: https://github.com/yujinakayama/transpec#supported-conversions
